### PR TITLE
feat: added notification permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,8 +4,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
             android:allowBackup="true"
@@ -23,8 +23,7 @@
         </activity>
         <activity
             android:name="com.github.muellerma.mute_reminder.PreferenceActivity"
-            android:exported="false"
-            />
+            android:exported="false" />
 
         <receiver
                 android:name=".BootReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
             android:allowBackup="true"

--- a/app/src/main/java/com/github/muellerma/mute_reminder/MainActivity.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/MainActivity.kt
@@ -6,8 +6,6 @@ import android.os.Bundle
 import android.provider.Settings
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContentProviderCompat.requireContext
-import androidx.core.content.ContextCompat.startActivity
 import androidx.core.view.isVisible
 import com.github.muellerma.mute_reminder.databinding.ActivityMainBinding
 
@@ -24,7 +22,7 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         supportActionBar?.hide()
-        setupListeners()
+        setupOnClickListeners()
         checkNotificationPermissionState()
     }
 
@@ -33,13 +31,13 @@ class MainActivity : AppCompatActivity() {
         handleNotificationPermission(hasNotificationPermission())
     }
 
-    private fun setupListeners() = with(binding) {
+    private fun setupOnClickListeners() = with(binding) {
         settings.setOnClickListener {
             Intent(this@MainActivity, PreferenceActivity::class.java).apply {
                 startActivity(this)
             }
         }
-        notificationButton.setOnClickListener { openNotificationSettings() }
+        notificationPermissions.setOnClickListener { openNotificationSettings() }
     }
 
     private fun checkNotificationPermissionState() {
@@ -51,10 +49,17 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun handleNotificationPermission(isGranted: Boolean) {
-        binding.notificationButton.isVisible = !isGranted
+        binding.notificationPermissions.isVisible = !isGranted
         if (isGranted) {
             ForegroundService.changeState(this, true)
         }
+    }
+
+    private fun hasNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true
+        }
+        return hasPermission(android.Manifest.permission.POST_NOTIFICATIONS)
     }
 
     private fun openNotificationSettings() {
@@ -66,5 +71,4 @@ class MainActivity : AppCompatActivity() {
             .putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
         startActivity(settingsIntent)
     }
-
 }

--- a/app/src/main/java/com/github/muellerma/mute_reminder/MainActivity.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/MainActivity.kt
@@ -28,20 +28,18 @@ class MainActivity : AppCompatActivity() {
         checkNotificationPermissionState()
     }
 
+    override fun onResume() {
+        super.onResume()
+        handleNotificationPermission(hasNotificationPermission())
+    }
+
     private fun setupListeners() = with(binding) {
         settings.setOnClickListener {
             Intent(this@MainActivity, PreferenceActivity::class.java).apply {
                 startActivity(this)
             }
         }
-        notificationButton.setOnClickListener {
-            openNotificationSettings()
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        handleNotificationPermission(hasNotificationPermission())
+        notificationButton.setOnClickListener { openNotificationSettings() }
     }
 
     private fun checkNotificationPermissionState() {

--- a/app/src/main/java/com/github/muellerma/mute_reminder/MainActivity.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/MainActivity.kt
@@ -1,24 +1,72 @@
 package com.github.muellerma.mute_reminder
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContentProviderCompat.requireContext
+import androidx.core.content.ContextCompat.startActivity
+import androidx.core.view.isVisible
 import com.github.muellerma.mute_reminder.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
+    private val notificationPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+        ::handleNotificationPermission
+    )
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = ActivityMainBinding.inflate(layoutInflater)
+        binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
         supportActionBar?.hide()
+        setupListeners()
+        checkNotificationPermissionState()
+    }
 
-        binding.settings.setOnClickListener {
-            Intent(this, PreferenceActivity::class.java).apply {
+    private fun setupListeners() = with(binding) {
+        settings.setOnClickListener {
+            Intent(this@MainActivity, PreferenceActivity::class.java).apply {
                 startActivity(this)
             }
         }
-
-        ForegroundService.changeState(this, true)
+        notificationButton.setOnClickListener {
+            openNotificationSettings()
+        }
     }
+
+    override fun onResume() {
+        super.onResume()
+        handleNotificationPermission(hasNotificationPermission())
+    }
+
+    private fun checkNotificationPermissionState() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            handleNotificationPermission(true)
+            return
+        }
+        notificationPermission.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    private fun handleNotificationPermission(isGranted: Boolean) {
+        binding.notificationButton.isVisible = !isGranted
+        if (isGranted) {
+            ForegroundService.changeState(this, true)
+        }
+    }
+
+    private fun openNotificationSettings() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return
+        }
+        val settingsIntent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+        startActivity(settingsIntent)
+    }
+
 }

--- a/app/src/main/java/com/github/muellerma/mute_reminder/Utils.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/Utils.kt
@@ -3,9 +3,13 @@ package com.github.muellerma.mute_reminder
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
+import android.provider.ContactsContract
 import android.util.Log
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 
 private const val TAG = "Utils"
 
@@ -19,4 +23,18 @@ fun String.openInBrowser(context: Context) {
             .makeText(context, R.string.error_no_browser_found, Toast.LENGTH_SHORT)
             .show()
     }
+}
+
+fun Context.hasPermission(string: String): Boolean {
+    return ContextCompat.checkSelfPermission(
+        this,
+        string
+    ) == PackageManager.PERMISSION_GRANTED
+}
+
+fun Context.hasNotificationPermission(): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        return true
+    }
+    return hasPermission(android.Manifest.permission.POST_NOTIFICATIONS)
 }

--- a/app/src/main/java/com/github/muellerma/mute_reminder/Utils.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/Utils.kt
@@ -31,10 +31,3 @@ fun Context.hasPermission(string: String): Boolean {
         string
     ) == PackageManager.PERMISSION_GRANTED
 }
-
-fun Context.hasNotificationPermission(): Boolean {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-        return true
-    }
-    return hasPermission(android.Manifest.permission.POST_NOTIFICATIONS)
-}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -54,5 +54,18 @@
             android:layout_marginEnd="16dp"
             android:text="@string/settings"
             android:textColor="?colorOnBackground" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/notificationButton"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:visibility="gone"
+            tools:visibility="visible"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="24dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/notification_permission_button"
+            android:textColor="?colorOnBackground" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -56,14 +56,14 @@
             android:textColor="?colorOnBackground" />
 
         <com.google.android.material.button.MaterialButton
-            android:id="@+id/notificationButton"
+            android:id="@+id/notification_permissions"
             style="@style/Widget.Material3.Button.OutlinedButton"
             android:layout_width="match_parent"
             android:visibility="gone"
             tools:visibility="visible"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="24dp"
+            android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
             android:text="@string/notification_permission_button"
             android:textColor="?colorOnBackground" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="notification_reminder_title">Reminder</string>
     <string name="notification_background_title">Background service</string>
     <string name="notification_background_summary">You can hide this notification category</string>
+    <string name="notification_permission_button">Give Notification Permission</string>
 
     <!-- Settings -->
     <string name="settings">Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,13 +10,13 @@
     <!-- MainActivity -->
     <string name="main_activity_hint">A notification is shown if ringtone is muted, but media isn\'t and media would be played over local speakers.</string>
     <string name="error_no_browser_found">No browser found</string>
+    <string name="notification_permission_button">Grant permission to show notifications</string>
 
     <!-- Notifications -->
     <string name="notification_reminder_text">Media not muted</string>
     <string name="notification_reminder_title">Reminder</string>
     <string name="notification_background_title">Background service</string>
     <string name="notification_background_summary">You can hide this notification category</string>
-    <string name="notification_permission_button">Give Notification Permission</string>
 
     <!-- Settings -->
     <string name="settings">Settings</string>


### PR DESCRIPTION
This closes #39.

For some reason the file spacing is different and GitHub is showing as if I changed the entire file (for example the Manifest I just added the line with the new permission). I tried to fix it to avoid showing the entire file as diff but it didn't work, hopefully it won't be a blocker.

I ask it the permission on app start only for android 13:
![image](https://user-images.githubusercontent.com/8679058/196215360-14e9b407-bf33-4bf3-97a6-adad7f329d7c.png)

And also added a button in case the user is permanently denied. This button just shows if it's android 13+ and the permission was denied.

Let me know if I should change anything else 