### PR TITLE
add a mute button to notification (resolve #54)

### DIFF
--- a/app/src/main/java/com/github/muellerma/mute_reminder/ForegroundService.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/ForegroundService.kt
@@ -1,7 +1,6 @@
 package com.github.muellerma.mute_reminder
 
 
-import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -66,7 +65,6 @@ class ForegroundService : Service() {
         if (key == Prefs.NOTIFY_ONLY_WHEN_MUTED) handleVolumeChanged()
     }
 
-    @SuppressLint("LaunchActivityFromNotification")//Notification actions are folded by default
     private fun handleVolumeChanged() {
         Log.d(TAG, "handleVolumeChanged()")
         val nm = getSystemService<NotificationManager>()!!
@@ -84,18 +82,21 @@ class ForegroundService : Service() {
                 val pendingIntent = PendingIntent.getService(this, 0, intent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent_Immutable
                 )
-
+                val muteAction=NotificationCompat.Action(
+                    R.drawable.ic_baseline_volume_mute_24,
+                    getString(R.string.mute_media),
+                    pendingIntent
+                )
                 val notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ALERT_ID)
                     .setContentTitle(getString(R.string.notification_reminder_text))
                     .setTicker(getString(R.string.notification_reminder_text))
-                    .setContentText(getString(R.string.notification_reminder_action))
                     .setSmallIcon(R.drawable.ic_baseline_volume_up_24)
                     .setOngoing(true)
                     .setShowWhen(true)
                     .setWhen(System.currentTimeMillis())
                     .setColor(ContextCompat.getColor(applicationContext, R.color.md_theme_light_primary))
                     .setCategory(NotificationCompat.CATEGORY_SERVICE)
-                    .setContentIntent(pendingIntent)
+                    .addAction(muteAction)
                 nm.notify(NOTIFICATION_ALERT_ID, notificationBuilder.build())
             }
             else -> {

--- a/app/src/main/java/com/github/muellerma/mute_reminder/ForegroundService.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/ForegroundService.kt
@@ -79,10 +79,13 @@ class ForegroundService : Service() {
                 //create pendingIntent, click to send mute action
                 val intent = Intent(this, ForegroundService::class.java)
                 intent.action = ACTION_MUTE_MEDIA
-                val pendingIntent = PendingIntent.getService(this, 0, intent,
+                val pendingIntent = PendingIntent.getService(
+                    this,
+                    0,
+                    intent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent_Immutable
                 )
-                val muteAction=NotificationCompat.Action(
+                val muteAction = NotificationCompat.Action(
                     R.drawable.ic_baseline_volume_mute_24,
                     getString(R.string.mute_media),
                     pendingIntent

--- a/app/src/main/java/com/github/muellerma/mute_reminder/ForegroundService.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/ForegroundService.kt
@@ -78,7 +78,7 @@ class ForegroundService : Service() {
 
                 //create pendingIntent, click to send mute action
                 val intent = Intent(this, ForegroundService::class.java)
-                intent.action = "ACTION_MUTE"
+                intent.action = ACTION_MUTE_MEDIA
                 val pendingIntent = PendingIntent.getService(this, 0, intent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent_Immutable
                 )
@@ -117,7 +117,7 @@ class ForegroundService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "onStartCommand()")
-        if (intent?.action == "ACTION_MUTE") {
+        if (intent?.action == ACTION_MUTE_MEDIA) {
             //already running
             mediaAudioManager.muteMedia()
             return START_STICKY
@@ -237,6 +237,8 @@ class ForegroundService : Service() {
         private const val NOTIFICATION_ALERT_ID = 2
         private const val NOTIFICATION_CHANNEL_SERVICE_ID = "service"
         private const val NOTIFICATION_CHANNEL_ALERT_ID = "alert"
+
+        private const val ACTION_MUTE_MEDIA = "ACTION_MUTE_MEDIA"
 
         fun changeState(context: Context, start: Boolean) {
             Log.d(TAG, "changeState($start)")

--- a/app/src/main/java/com/github/muellerma/mute_reminder/MainActivity.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.core.view.isVisible
 import com.github.muellerma.mute_reminder.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
-
+    private lateinit var mediaAudioManager: MediaAudioManager
     private lateinit var binding: ActivityMainBinding
     private val notificationPermission = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -22,6 +22,7 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         supportActionBar?.hide()
+        mediaAudioManager = MediaAudioManager(this)
         setupOnClickListeners()
         checkNotificationPermissionState()
     }
@@ -38,6 +39,9 @@ class MainActivity : AppCompatActivity() {
             }
         }
         notificationPermissions.setOnClickListener { openNotificationSettings() }
+        muteMedia.setOnClickListener {
+            mediaAudioManager.muteMedia()
+        }
     }
 
     private fun checkNotificationPermissionState() {

--- a/app/src/main/java/com/github/muellerma/mute_reminder/MediaAudioManager.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/MediaAudioManager.kt
@@ -5,7 +5,6 @@ import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.os.Build
 import android.util.Log
-import android.widget.Toast
 import androidx.core.content.getSystemService
 
 class MediaAudioManager(private val context: Context) {
@@ -21,7 +20,7 @@ class MediaAudioManager(private val context: Context) {
         }
         catch (e: SecurityException){
             // setStreamVolume may fail at don't-disturb Mode
-            Toast.makeText(context,R.string.mute_media_failed,Toast.LENGTH_SHORT).show()
+            context.showToast(R.string.mute_media_failed)
         }
     }
     private fun isMediaMuted(): Boolean {

--- a/app/src/main/java/com/github/muellerma/mute_reminder/MediaAudioManager.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/MediaAudioManager.kt
@@ -5,16 +5,25 @@ import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.os.Build
 import android.util.Log
+import android.widget.Toast
 import androidx.core.content.getSystemService
 
-class MediaAudioManager(context: Context) {
+class MediaAudioManager(private val context: Context) {
     private val audioManager: AudioManager = context.getSystemService()!!
     private val prefs = Prefs(context)
 
     fun shouldNotify(): Boolean {
         return (!prefs.notifyOnlyWhenMuted || isRingToneMuted()) && !isMediaMuted() && !usesRemoteOutput()
     }
-
+    fun muteMedia(){
+        try {
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC,0 ,AudioManager.FLAG_SHOW_UI)
+        }
+        catch (e: SecurityException){
+            // setStreamVolume may fail at don't-disturb Mode
+            Toast.makeText(context,R.string.mute_media_failed,Toast.LENGTH_SHORT).show()
+        }
+    }
     private fun isMediaMuted(): Boolean {
         val mediaVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
         Log.d(TAG, "mediaVolume=$mediaVolume")

--- a/app/src/main/java/com/github/muellerma/mute_reminder/MediaAudioManager.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/MediaAudioManager.kt
@@ -14,15 +14,16 @@ class MediaAudioManager(private val context: Context) {
     fun shouldNotify(): Boolean {
         return (!prefs.notifyOnlyWhenMuted || isRingToneMuted()) && !isMediaMuted() && !usesRemoteOutput()
     }
-    fun muteMedia(){
+
+    fun muteMedia() {
         try {
-            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC,0 ,AudioManager.FLAG_SHOW_UI)
-        }
-        catch (e: SecurityException){
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, AudioManager.FLAG_SHOW_UI)
+        } catch (e: SecurityException) {
             // setStreamVolume may fail at don't-disturb Mode
             context.showToast(R.string.mute_media_failed)
         }
     }
+
     private fun isMediaMuted(): Boolean {
         val mediaVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
         Log.d(TAG, "mediaVolume=$mediaVolume")

--- a/app/src/main/java/com/github/muellerma/mute_reminder/Utils.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/Utils.kt
@@ -1,12 +1,12 @@
 package com.github.muellerma.mute_reminder
 
+import android.app.PendingIntent
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
-import android.provider.ContactsContract
 import android.util.Log
 import android.widget.Toast
 import androidx.core.content.ContextCompat
@@ -30,4 +30,15 @@ fun Context.hasPermission(string: String): Boolean {
         this,
         string
     ) == PackageManager.PERMISSION_GRANTED
+}
+val PendingIntent_Immutable = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    PendingIntent.FLAG_IMMUTABLE
+} else {
+    0
+}
+
+val PendingIntent_Mutable = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    PendingIntent.FLAG_MUTABLE
+} else {
+    0
 }

--- a/app/src/main/java/com/github/muellerma/mute_reminder/Utils.kt
+++ b/app/src/main/java/com/github/muellerma/mute_reminder/Utils.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.os.Build
 import android.util.Log
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 
 private const val TAG = "Utils"
@@ -19,9 +20,7 @@ fun String.openInBrowser(context: Context) {
         context.startActivity(intent)
     } catch (e: ActivityNotFoundException) {
         Log.d(TAG, "Unable to open url in browser: $intent")
-        Toast
-            .makeText(context, R.string.error_no_browser_found, Toast.LENGTH_SHORT)
-            .show()
+        context.showToast(R.string.error_no_browser_found)
     }
 }
 
@@ -31,6 +30,12 @@ fun Context.hasPermission(string: String): Boolean {
         string
     ) == PackageManager.PERMISSION_GRANTED
 }
+fun Context.showToast(@StringRes msg: Int) {
+    Toast
+        .makeText(this, msg, Toast.LENGTH_SHORT)
+        .show()
+}
+
 val PendingIntent_Immutable = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
     PendingIntent.FLAG_IMMUTABLE
 } else {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -67,5 +67,15 @@
             android:layout_marginEnd="16dp"
             android:text="@string/notification_permission_button"
             android:textColor="?colorOnBackground" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/mute_media"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/mute_media"
+            android:textColor="?colorOnBackground" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -67,6 +67,7 @@
             android:layout_marginEnd="16dp"
             android:text="@string/notification_permission_button"
             android:textColor="?colorOnBackground" />
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/mute_media"
             style="@style/Widget.Material3.Button.OutlinedButton"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
     <string name="mute_media_failed">Failed to mute volume</string>
     <!-- Notifications -->
     <string name="notification_reminder_text">Media not muted</string>
-    <string name="notification_reminder_action">Tap to mute media volume</string>
     <string name="notification_reminder_title">Reminder</string>
     <string name="notification_background_title">Background service</string>
     <string name="notification_background_summary">You can hide this notification category</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,9 +11,11 @@
     <string name="main_activity_hint">A notification is shown if ringtone is muted, but media isn\'t and media would be played over local speakers. You can change this behavior in the settings.</string>
     <string name="error_no_browser_found">No browser found</string>
     <string name="notification_permission_button">Grant permission to show notifications</string>
-
+    <string name="mute_media">Mute media volume</string>
+    <string name="mute_media_failed">Failed to mute volume</string>
     <!-- Notifications -->
     <string name="notification_reminder_text">Media not muted</string>
+    <string name="notification_reminder_action">Tap to mute media volume</string>
     <string name="notification_reminder_title">Reminder</string>
     <string name="notification_background_title">Background service</string>
     <string name="notification_background_summary">You can hide this notification category</string>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.7.21"
+    ext.kotlin_version = "1.8.0"
     ext.about_libraries_version = "10.5.2"
     repositories {
         google()


### PR DESCRIPTION
1. Implemented issue #54 by sending custom intent and handling it in ForegroudService, without the need of extra system permission.
   The linter recommended using `setAction()` to send intent from notification. Considering that when the reminder is triggered, to mute can be an urgently needed operation, I suppose tapping the notification is more intuitive than action buttons.
 
3. Added a mute button at main activity, in case the user wants to mute manually
4. Set iconSpaceReserved=false for all preferences in Settings, for a better appearance

