### PR TITLE
[CI] Upload unsigned apk after build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,9 @@ jobs:
 
       - name: Build
         run: bash gradlew build
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-apk
+          path: app/build/outputs/apk


### PR DESCRIPTION
Add unsigned apk artifact upload to build workflow, allowing testers to directly obtain build versions from CI without having to compile it themselves.